### PR TITLE
Add xarf option to process JSON content in arf_parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The following options are available in the **options** array.
 
 - original_message `boolean` - Include the original mail message in the output (if it exists), the default is `false`
 - original_headers `boolean` - Include the original mail message headers in the output (if they exist), the default is `false`
+- xarf `boolean` - process the xarf application/json content (if it exists), the default is `false`
 
 ```
 {

--- a/arf.hsl
+++ b/arf.hsl
@@ -1,4 +1,4 @@
-function arf_parse($mail, $options = ["original_message" => false, "original_headers" => false])
+function arf_parse($mail, $options = ["original_message" => false, "original_headers" => false, "xarf" => false])
 {
     if ($mail->getType() !== "multipart/report")
         return none;
@@ -46,6 +46,16 @@ function arf_parse($mail, $options = ["original_message" => false, "original_hea
             $body = $parts[0]->getBody();
             if ($body) {
                 $arf["original_headers"] = $body;
+            }
+        }
+    }
+
+    if ($options["xarf"]) {
+        $parts = $mail->findByType(''^application/json$'');
+        if ($parts) {
+            $body = $parts[0]->getBody();
+            if ($body) {
+                $arf["xarf"] = json_decode($body);
             }
         }
     }


### PR DESCRIPTION
- Updated `README.md` to document the new `xarf` option.
- Modified `arf_parse` function to handle `xarf` option.
- Added logic to parse `application/json` content when `xarf` is true.